### PR TITLE
UnmarshalBinaryResponse: don't error out if there are no trailers

### DIFF
--- a/bhttp.go
+++ b/bhttp.go
@@ -568,7 +568,7 @@ func UnmarshalBinaryResponse(data []byte) (*http.Response, error) {
 	// Trailer
 	trailerFields := new(fieldList)
 	encodedFieldData, err = readVarintSlice(b)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return nil, err
 	}
 	err = trailerFields.Unmarshal(bytes.NewBuffer(encodedFieldData))


### PR DESCRIPTION
A binary response may not have trailers, and may not include an empty map in that case.

Don't prematurely return an error when it happens.