### PR TITLE
client changes required for chunked responses

### DIFF
--- a/client.go
+++ b/client.go
@@ -131,13 +131,13 @@ func (c *EncapsulatedRequestContext) EncapsulateRequestChunk(requestChunk []byte
 	}, nil
 }
 
-func (c *EncapsulatedRequestContext) EncapsulateFinalRequestChunk(requestChunk []byte) (EncapsulatedRequestChunk, error) {
+func (c *EncapsulatedRequestContext) EncapsulateFinalRequestChunk(requestChunk []byte) (EncapsulatedFinalRequestChunk, error) {
 	ct, err := c.context.Seal(requestChunk, []byte("final"))
 	if err != nil {
-		return EncapsulatedRequestChunk{}, err
+		return EncapsulatedFinalRequestChunk{}, err
 	}
 
-	return EncapsulatedRequestChunk{
+	return EncapsulatedFinalRequestChunk{
 		ct: ct,
 	}, nil
 }

--- a/gateway.go
+++ b/gateway.go
@@ -271,7 +271,7 @@ func (s *GatewayRequestContext) DecapsulateRequestChunk(requestChunk Encapsulate
 	return s.opener.Open(requestChunk.ct, nil)
 }
 
-func (s *GatewayRequestContext) DecapsulateFinalRequestChunk(requestChunk EncapsulatedRequestChunk) ([]byte, error) {
+func (s *GatewayRequestContext) DecapsulateFinalRequestChunk(requestChunk EncapsulatedFinalRequestChunk) ([]byte, error) {
 	return s.opener.Open(requestChunk.ct, []byte("final"))
 }
 

--- a/messages.go
+++ b/messages.go
@@ -107,6 +107,10 @@ type EncapsulatedRequestChunk struct {
 	ct []byte
 }
 
+type EncapsulatedFinalRequestChunk struct {
+	ct []byte
+}
+
 //	Non-Final Request Chunk {
 //		Length (i) = 1..,
 //		HPKE-Protected Chunk (..),
@@ -117,6 +121,17 @@ func (r EncapsulatedRequestChunk) Marshal() []byte {
 	buffer := bytes.NewBuffer(nil)
 	Write(buffer, uint64(len(r.ct)))
 	b.AddBytes(buffer.Bytes())
+	b.AddBytes(r.ct)
+
+	return b.BytesOrPanic()
+}
+
+// Final Request Chunk Indicator (i) = 0,
+// HPKE-Protected Final Chunk (..),
+func (r EncapsulatedFinalRequestChunk) Marshal() []byte {
+	b := cryptobyte.NewBuilder(nil)
+
+	b.AddBytes([]byte{0})
 	b.AddBytes(r.ct)
 
 	return b.BytesOrPanic()


### PR DESCRIPTION
In this PR we:
- prefix the final chunk with a zero to mark it as the last one.
- streaming api for converting chunked hpke response bodies
- streaming api for parsing indeterminate-length bhttp bodies. Note, this is missing indeterminate-length trailers conversion.

Todo:
- [x] Add indeterminate-length bhttp response parsing
- [ ] Update tests to use the new streaming bhttp/hpke readers

I'm by no means an experienced go programmer. Any feedback is very much welcome!