### PR TITLE
Use canonical form for http header keys in UnmarshalBinaryResponse

### DIFF
--- a/bhttp.go
+++ b/bhttp.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"strings"
 )
@@ -556,7 +557,7 @@ func UnmarshalBinaryResponse(data []byte) (*http.Response, error) {
 	}
 	headerMap := make(map[string][]string)
 	for _, field := range headerFields.fields {
-		headerMap[field.name] = []string{field.value}
+		headerMap[textproto.CanonicalMIMEHeaderKey(field.name)] = []string{field.value}
 	}
 
 	// Content


### PR DESCRIPTION
hi,
This PR is to fix this issue: https://github.com/chris-wood/ohttp-go/issues/31
