### PR TITLE
Add possibility to add and drop hpke configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+test:
+	go test ./...
+
+all: test

--- a/ohttp.go
+++ b/ohttp.go
@@ -418,20 +418,23 @@ func (g Gateway) Config(keyID uint8) (PublicConfig, error) {
 	return PublicConfig{}, fmt.Errorf("unknown keyID %d", keyID)
 }
 
-func (g *Gateway) DropConfig(keyID uint8) error {
-	if _, ok := g.keyMap[keyID]; ok {
-		delete(g.keyMap, keyID)
-		newKeys := make([]uint8, 0)
-		for keyId := range g.keyMap {
-			newKeys = append(newKeys, keyId)
-		}
-		g.keys = newKeys
-
+func (g *Gateway) DropKeyFromConfig(keyID uint8) error {
+	if _, ok := g.keyMap[keyID]; !ok {
+		return fmt.Errorf("unknown keyID %d", keyID)
 	}
-	return fmt.Errorf("unknown keyID %d", keyID)
+
+	delete(g.keyMap, keyID)
+
+	newKeys := make([]uint8, 0, len(g.keys)-1)
+	for key := range g.keyMap {
+		newKeys = append(newKeys, key)
+	}
+	g.keys = newKeys
+
+	return nil
 }
 
-func (g *Gateway) AddConfig(config PrivateConfig) error {
+func (g *Gateway) AddKeyToConfig(config PrivateConfig) error {
 	if _, exists := g.keyMap[config.publicConfig.ID]; exists {
 		return fmt.Errorf("duplicate config key ID")
 	}

--- a/ohttp.go
+++ b/ohttp.go
@@ -418,6 +418,30 @@ func (g Gateway) Config(keyID uint8) (PublicConfig, error) {
 	return PublicConfig{}, fmt.Errorf("unknown keyID %d", keyID)
 }
 
+func (g *Gateway) DropConfig(keyID uint8) error {
+	if _, ok := g.keyMap[keyID]; ok {
+		delete(g.keyMap, keyID)
+		newKeys := make([]uint8, 0)
+		for keyId := range g.keyMap {
+			newKeys = append(newKeys, keyId)
+		}
+		g.keys = newKeys
+
+	}
+	return fmt.Errorf("unknown keyID %d", keyID)
+}
+
+func (g *Gateway) AddConfig(config PrivateConfig) error {
+	if _, exists := g.keyMap[config.publicConfig.ID]; exists {
+		return fmt.Errorf("duplicate config key ID")
+	}
+
+	g.keyMap[config.publicConfig.ID] = config
+	g.keys = append(g.keys, config.publicConfig.ID)
+
+	return nil
+}
+
 func (g Gateway) Client(keyID uint8) (Client, error) {
 	config, err := g.Config(keyID)
 	if err != nil {

--- a/ohttp_test.go
+++ b/ohttp_test.go
@@ -582,14 +582,16 @@ func BenchmarkRoundTrip(b *testing.B) {
 	})
 }
 
-func PopAndAddConfigs(b *testing.B) {
+func TestPopAndAddConfigs(t *testing.T) {
+
 	privateConfig, err := NewConfig(0x00, hpke.KEM_X25519_HKDF_SHA256, hpke.KDF_HKDF_SHA256, hpke.AEAD_AES128GCM)
-	require.Nil(b, err, "CreatePrivateConfig failed")
+	require.Nil(t, err, "CreatePrivateConfig failed")
 
 	server := NewDefaultGateway([]PrivateConfig{privateConfig})
-	err = server.DropConfig(0x00)
-	require.Nil(b, err, "DropConfig failed")
 
-	err = server.AddConfig(privateConfig)
-	require.Nil(b, err, "AddConfig failed")
+	err = server.DropKeyFromConfig(0x00)
+	require.Nil(t, err, "DropConfig failed")
+
+	err = server.AddKeyToConfig(privateConfig)
+	require.Nil(t, err, "DropConfig failed")
 }

--- a/ohttp_test.go
+++ b/ohttp_test.go
@@ -581,3 +581,15 @@ func BenchmarkRoundTrip(b *testing.B) {
 		require.Equal(b, rawResponse, receivedResp, "Response mismatch")
 	})
 }
+
+func PopAndAddConfigs(b *testing.B) {
+	privateConfig, err := NewConfig(0x00, hpke.KEM_X25519_HKDF_SHA256, hpke.KDF_HKDF_SHA256, hpke.AEAD_AES128GCM)
+	require.Nil(b, err, "CreatePrivateConfig failed")
+
+	server := NewDefaultGateway([]PrivateConfig{privateConfig})
+	err = server.DropConfig(0x00)
+	require.Nil(b, err, "DropConfig failed")
+
+	err = server.AddConfig(privateConfig)
+	require.Nil(b, err, "AddConfig failed")
+}


### PR DESCRIPTION
**What**
This PR aims to enable the dynamic addition and removal of HPKE configurations on a specific gateway during runtime.

**Why**
For example, as highlighted in [this issue](https://chat.deepseek.com/a/chat/s/cloudflare/privacy-gateway-server-go#11), to support key rotation, it is crucial to have the ability to automatically remove expired HPKE configurations and their associated keys after a defined cryptoperiod instead of re-creating the entire gateway.