### PR TITLE
Add support for indeterminate-length requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GoDoc](https://godoc.org/github.com/cloudflare/circl?status.svg)](https://pkg.go.dev/github.com/chris-wood/ohttp-go?tab=overview)
 [![Go Report Card](https://goreportcard.com/badge/github.com/cloudflare/circl)](https://goreportcard.com/report/github.com/chris-wood/ohttp-go)
 
-This library contains an implementation of [Oblivious HTTP](https://datatracker.ietf.org/doc/draft-thomson-http-oblivious/) and binary representations of HTTP messages ([RFC9292](https://datatracker.ietf.org/doc/html/rfc9292)). Binary HTTP support is limited to known-length messages. Indeterminate-length messages are not currently supported.
+This library contains an implementation of [Oblivious HTTP](https://datatracker.ietf.org/doc/draft-thomson-http-oblivious/) and binary representations of HTTP messages ([RFC9292](https://datatracker.ietf.org/doc/html/rfc9292)). Binary HTTP support is limited to known-length messages and indeterminate-length requests. Indeterminate-length responses are not currently supported.
 
 ## Security Disclaimer
 

--- a/bhttp.go
+++ b/bhttp.go
@@ -236,6 +236,9 @@ func UnmarshalBinaryRequest(data []byte) (*http.Request, error) {
 	for _, field := range headerFields.fields {
 		request.Header.Set(field.name, field.value)
 	}
+	if len(trailerFields.fields) > 0 {
+		request.Trailer = make(http.Header)
+	}
 	for _, field := range trailerFields.fields {
 		request.Trailer.Set(field.name, field.value)
 	}

--- a/bhttp.go
+++ b/bhttp.go
@@ -27,6 +27,8 @@ const (
 var (
 	errProhibitedField           = errors.New("Prohibited field detected")
 	errInformationalNotSupported = errors.New("Informational messages not supported")
+	errUnexpectedResponseFrame   = errors.New("Expected binary HTTP request, not binary HTTP response")
+	errUnsupportedMessageType    = errors.New("Unsupported binary HTTP message type")
 )
 
 func isProhibitedField(fieldName string) bool {
@@ -126,11 +128,12 @@ func UnmarshalBinaryRequest(data []byte) (*http.Request, error) {
 	case knownLengthRequestFrame:
 		break
 	case knownLengthResponseFrame:
-		return nil, fmt.Errorf("Expected binary HTTP request, not binary HTTP response")
+		return nil, errUnexpectedResponseFrame
 	case unknownLengthRequestFrame:
 	case unknownLengthResponseFrame:
+		return nil, errUnexpectedResponseFrame
 	default:
-		return nil, fmt.Errorf("Unsupported binary HTTP message type")
+		return nil, errUnsupportedMessageType
 	}
 
 	// Control data

--- a/bhttp.go
+++ b/bhttp.go
@@ -74,6 +74,64 @@ func readVarintSlice(b *bytes.Buffer) ([]byte, error) {
 	return value, nil
 }
 
+func readZeroDelimitedSlice(b *bytes.Buffer) ([]byte, error) {
+	data, err := b.ReadBytes(0)
+	if err != nil {
+		return nil, err
+	}
+
+	return data[:len(data)-1], nil
+}
+
+func readSlice(b *bytes.Buffer, indicator frameIndicator) ([]byte, error) {
+	switch indicator {
+	case knownLengthRequestFrame, knownLengthResponseFrame:
+		return readVarintSlice(b)
+	case unknownLengthRequestFrame, unknownLengthResponseFrame:
+		return readZeroDelimitedSlice(b)
+	default:
+		return nil, errUnsupportedMessageType
+	}
+}
+
+func readContent(b *bytes.Buffer, indicator frameIndicator) ([]byte, error) {
+	switch indicator {
+	case knownLengthRequestFrame, knownLengthResponseFrame:
+		return readVarintSlice(b)
+	case unknownLengthRequestFrame, unknownLengthResponseFrame:
+		slice, err := readZeroDelimitedSlice(b)
+		if err != nil {
+			return nil, err
+		}
+
+		return readContentChunks(bytes.NewBuffer(slice))
+	default:
+		return nil, errUnsupportedMessageType
+	}
+}
+
+func readContentChunks(b *bytes.Buffer) ([]byte, error) {
+	out := new(bytes.Buffer)
+
+	for {
+		if b.Len() == 0 {
+			break
+		}
+
+		chunk, err := readVarintSlice(b)
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = out.Write(chunk)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return out.Bytes(), nil
+}
+
 //	Request with Known-Length {
 //		Framing Indicator (i) = 0,
 //		Request Control Data (..),
@@ -125,12 +183,9 @@ func UnmarshalBinaryRequest(data []byte) (*http.Request, error) {
 
 	// Filter based on the type of frame
 	switch indicator {
-	case knownLengthRequestFrame:
+	case knownLengthRequestFrame, unknownLengthRequestFrame:
 		break
-	case knownLengthResponseFrame:
-		return nil, errUnexpectedResponseFrame
-	case unknownLengthRequestFrame:
-	case unknownLengthResponseFrame:
+	case knownLengthResponseFrame, unknownLengthResponseFrame:
 		return nil, errUnexpectedResponseFrame
 	default:
 		return nil, errUnsupportedMessageType
@@ -168,7 +223,7 @@ func UnmarshalBinaryRequest(data []byte) (*http.Request, error) {
 
 	// Header fields
 	headerFields := new(fieldList)
-	encodedFieldData, err := readVarintSlice(b)
+	encodedFieldData, err := readSlice(b, indicator)
 	if err != nil {
 		return nil, err
 	}
@@ -199,13 +254,13 @@ func UnmarshalBinaryRequest(data []byte) (*http.Request, error) {
 
 	// Content and trailers
 	trailerFields := new(fieldList)
-	content, err := readVarintSlice(b)
+	content, err := readContent(b, indicator)
 	if err != nil {
 		return nil, err
 	}
 	if len(content) == 0 {
 		// Content was truncated, so the trailers MUST also be truncated
-		trailers, err := readVarintSlice(b)
+		trailers, err := readSlice(b, indicator)
 		if err != nil {
 			return nil, err
 		}
@@ -214,7 +269,7 @@ func UnmarshalBinaryRequest(data []byte) (*http.Request, error) {
 		}
 	} else {
 		// Content field was not truncated, so now check for trailers
-		encodedFieldData, err = readVarintSlice(b)
+		encodedFieldData, err = readSlice(b, indicator)
 		if err != nil {
 			return nil, err
 		}

--- a/bhttp.go
+++ b/bhttp.go
@@ -99,12 +99,7 @@ func readContent(b *bytes.Buffer, indicator frameIndicator) ([]byte, error) {
 	case knownLengthRequestFrame, knownLengthResponseFrame:
 		return readVarintSlice(b)
 	case unknownLengthRequestFrame, unknownLengthResponseFrame:
-		slice, err := readZeroDelimitedSlice(b)
-		if err != nil {
-			return nil, err
-		}
-
-		return readContentChunks(bytes.NewBuffer(slice))
+		return readContentChunks(b)
 	default:
 		return nil, errUnsupportedMessageType
 	}
@@ -121,6 +116,10 @@ func readContentChunks(b *bytes.Buffer) ([]byte, error) {
 		chunk, err := readVarintSlice(b)
 		if err != nil {
 			return nil, err
+		}
+
+		if len(chunk) == 0 {
+			break
 		}
 
 		_, err = out.Write(chunk)
@@ -270,7 +269,7 @@ func UnmarshalBinaryRequest(data []byte) (*http.Request, error) {
 	} else {
 		// Content field was not truncated, so now check for trailers
 		encodedFieldData, err = readSlice(b, indicator)
-		if err != nil {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return nil, err
 		}
 		if len(encodedFieldData) > 0 {

--- a/bhttp_test.go
+++ b/bhttp_test.go
@@ -608,6 +608,32 @@ func TestRequestUnmarshal(t *testing.T) {
 				// empty
 			},
 		},
+		{
+			request: createFullRequestFromParts(http.MethodGet, "https://example.com/index.html", testHeaderMap, testTrailerMap, []byte("b\x00dyn\x00tb\x00dy")),
+			enc: []byte{
+				// Framing indicator
+				byte(unknownLengthRequestFrame),
+				// Request Control Data
+				3, 'G', 'E', 'T',
+				5, 'h', 't', 't', 'p', 's',
+				11, 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm',
+				11, '/', 'i', 'n', 'd', 'e', 'x', '.', 'h', 't', 'm', 'l',
+				// Indeterminate-Length Field Section (Headers)
+				10, 't', 'e', 's', 't', 'h', 'e', 'a', 'd', 'e', 'r',
+				3, 'f', 'o', 'o',
+				0, // terminator
+				// Indeterminate-Length Content
+				4, 'b', 0, 'd', 'y',
+				7, 'n', 0, 't', 'b', 0, 'd', 'y',
+				0, // terminator
+				// Indeterminate-Length Field Section (Trailers)
+				11, 't', 'e', 's', 't', 't', 'r', 'a', 'i', 'l', 'e', 'r',
+				3, 'b', 'a', 'r',
+				0, // terminator
+				// Padding
+				// empty
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/bhttp_test.go
+++ b/bhttp_test.go
@@ -493,6 +493,121 @@ func TestRequestUnmarshal(t *testing.T) {
 				// empty
 			},
 		},
+		{
+			request: createRequestFromParts(http.MethodGet, "https://example.com/index.html", nil),
+			enc: []byte{
+				// Framing indicator
+				byte(unknownLengthRequestFrame),
+				// Request Control Data
+				3, 'G', 'E', 'T',
+				5, 'h', 't', 't', 'p', 's',
+				11, 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm',
+				11, '/', 'i', 'n', 'd', 'e', 'x', '.', 'h', 't', 'm', 'l',
+				// Indeterminate-Length Field Section (Headers)
+				0, // terminator
+				// Indeterminate-Length Content
+				0, // terminator
+				// Indeterminate-Length Field Section (Trailers)
+				0, // terminator
+				// Padding
+				// empty
+			},
+		},
+		{
+			request: createRequestFromParts(http.MethodGet, "https://example.com/index.html", []byte("body")),
+			enc: []byte{
+				// Framing indicator
+				byte(unknownLengthRequestFrame),
+				// Request Control Data
+				3, 'G', 'E', 'T',
+				5, 'h', 't', 't', 'p', 's',
+				11, 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm',
+				11, '/', 'i', 'n', 'd', 'e', 'x', '.', 'h', 't', 'm', 'l',
+				// Indeterminate-Length Field Section (Headers)
+				0, // terminator
+				// Indeterminate-Length Content
+				4, 'b', 'o', 'd', 'y',
+				0, //terminator
+				// Indeterminate-Length Field Section (Trailers)
+				0, // terminator
+				// Padding
+				// empty
+			},
+		},
+		{
+			request: createFullRequestFromParts(http.MethodGet, "https://example.com/index.html", testHeaderMap, nil, []byte("body")),
+			enc: []byte{
+				// Framing indicator
+				byte(unknownLengthRequestFrame),
+				// Request Control Data
+				3, 'G', 'E', 'T',
+				5, 'h', 't', 't', 'p', 's',
+				11, 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm',
+				11, '/', 'i', 'n', 'd', 'e', 'x', '.', 'h', 't', 'm', 'l',
+				// Indeterminate-Length Field Section (Headers)
+				10, 't', 'e', 's', 't', 'h', 'e', 'a', 'd', 'e', 'r',
+				3, 'f', 'o', 'o',
+				0, // terminator
+				// Indeterminate-Length Content
+				4, 'b', 'o', 'd', 'y',
+				0, // terminator
+				// Indeterminate-Length Field Section (Trailers)
+				0, // empty list of fields
+				// Padding
+				// empty
+			},
+		},
+		{
+			request: createFullRequestFromParts(http.MethodGet, "https://example.com/index.html", testHeaderMap, testTrailerMap, []byte("body")),
+			enc: []byte{
+				// Framing indicator
+				byte(unknownLengthRequestFrame),
+				// Request Control Data
+				3, 'G', 'E', 'T',
+				5, 'h', 't', 't', 'p', 's',
+				11, 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm',
+				11, '/', 'i', 'n', 'd', 'e', 'x', '.', 'h', 't', 'm', 'l',
+				// Indeterminate-Length Field Section (Headers)
+				10, 't', 'e', 's', 't', 'h', 'e', 'a', 'd', 'e', 'r',
+				3, 'f', 'o', 'o',
+				0, // terminator
+				// Indeterminate-Length Content
+				4, 'b', 'o', 'd', 'y',
+				0, // terminator
+				// Indeterminate-Length Field Section (Trailers)
+				11, 't', 'e', 's', 't', 't', 'r', 'a', 'i', 'l', 'e', 'r',
+				3, 'b', 'a', 'r',
+				0, // terminator
+				// Padding
+				// empty
+			},
+		},
+		{
+			request: createFullRequestFromParts(http.MethodGet, "https://example.com/index.html", testHeaderMap, testTrailerMap, []byte("bodynotbody")),
+			enc: []byte{
+				// Framing indicator
+				byte(unknownLengthRequestFrame),
+				// Request Control Data
+				3, 'G', 'E', 'T',
+				5, 'h', 't', 't', 'p', 's',
+				11, 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm',
+				11, '/', 'i', 'n', 'd', 'e', 'x', '.', 'h', 't', 'm', 'l',
+				// Indeterminate-Length Field Section (Headers)
+				10, 't', 'e', 's', 't', 'h', 'e', 'a', 'd', 'e', 'r',
+				3, 'f', 'o', 'o',
+				0, // terminator
+				// Indeterminate-Length Content
+				4, 'b', 'o', 'd', 'y',
+				7, 'n', 'o', 't', 'b', 'o', 'd', 'y',
+				0, // terminator
+				// Indeterminate-Length Field Section (Trailers)
+				11, 't', 'e', 's', 't', 't', 'r', 'a', 'i', 'l', 'e', 'r',
+				3, 'b', 'a', 'r',
+				0, // terminator
+				// Padding
+				// empty
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/bhttp_test.go
+++ b/bhttp_test.go
@@ -336,6 +336,184 @@ func TestRequestMarshal(t *testing.T) {
 	}
 }
 
+func TestRequestUnmarshal(t *testing.T) {
+	testHeaderMap := make(map[string]string)
+	testHeaderMap["TestHeader"] = "foo" // len("TestHeader") == 10, len("foo") == 3
+	testTrailerMap := make(map[string]string)
+	testTrailerMap["TestTrailer"] = "bar" // len("TestTrailer") == 11, len("bar") == 3
+
+	tests := []struct {
+		request       *http.Request
+		enc           []byte
+		expectedError error
+	}{
+		{
+			expectedError: errUnexpectedResponseFrame,
+			enc: []byte{
+				// Framing indicator
+				byte(knownLengthResponseFrame),
+				// Request Control Data
+				3, 'G', 'E', 'T',
+				5, 'h', 't', 't', 'p', 's',
+				11, 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm',
+				11, '/', 'i', 'n', 'd', 'e', 'x', '.', 'h', 't', 'm', 'l',
+				// Known-Length Field Section (Headers)
+				0, // empty list of fields
+				// Known-Length Content
+				4, 'b', 'o', 'd', 'y',
+				// Known-Length Field Section (Trailers)
+				0, // empty list of fields
+				// Padding
+				// empty
+			},
+		},
+		{
+			expectedError: errUnexpectedResponseFrame,
+			enc: []byte{
+				// Framing indicator
+				byte(unknownLengthResponseFrame),
+				// Request Control Data
+				3, 'G', 'E', 'T',
+				5, 'h', 't', 't', 'p', 's',
+				11, 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm',
+				11, '/', 'i', 'n', 'd', 'e', 'x', '.', 'h', 't', 'm', 'l',
+				// Known-Length Field Section (Headers)
+				0, // empty list of fields
+				// Known-Length Content
+				4, 'b', 'o', 'd', 'y',
+				// Known-Length Field Section (Trailers)
+				0, // empty list of fields
+				// Padding
+				// empty
+			},
+		},
+		{
+			expectedError: errUnsupportedMessageType,
+			enc: []byte{
+				// Framing indicator
+				byte(10),
+				// Request Control Data
+				3, 'G', 'E', 'T',
+				5, 'h', 't', 't', 'p', 's',
+				11, 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm',
+				11, '/', 'i', 'n', 'd', 'e', 'x', '.', 'h', 't', 'm', 'l',
+				// Known-Length Field Section (Headers)
+				0, // empty list of fields
+				// Known-Length Content
+				4, 'b', 'o', 'd', 'y',
+				// Known-Length Field Section (Trailers)
+				0, // empty list of fields
+				// Padding
+				// empty
+			},
+		},
+		{
+			request: createRequestFromParts(http.MethodGet, "https://example.com/index.html", nil),
+			enc: []byte{
+				// Framing indicator
+				byte(knownLengthRequestFrame),
+				// Request Control Data
+				3, 'G', 'E', 'T',
+				5, 'h', 't', 't', 'p', 's',
+				11, 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm',
+				11, '/', 'i', 'n', 'd', 'e', 'x', '.', 'h', 't', 'm', 'l',
+				// Known-Length Field Section (Headers)
+				0, // empty list of fields
+				// Known-Length Content
+				0, // empty content
+				// Known-Length Field Section (Trailers)
+				0, // empty list of fields
+				// Padding
+				// empty
+			},
+		},
+		{
+			request: createRequestFromParts(http.MethodGet, "https://example.com/index.html", []byte("body")),
+			enc: []byte{
+				// Framing indicator
+				byte(knownLengthRequestFrame),
+				// Request Control Data
+				3, 'G', 'E', 'T',
+				5, 'h', 't', 't', 'p', 's',
+				11, 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm',
+				11, '/', 'i', 'n', 'd', 'e', 'x', '.', 'h', 't', 'm', 'l',
+				// Known-Length Field Section (Headers)
+				0, // empty list of fields
+				// Known-Length Content
+				4, 'b', 'o', 'd', 'y',
+				// Known-Length Field Section (Trailers)
+				0, // empty list of fields
+				// Padding
+				// empty
+			},
+		},
+		{
+			request: createFullRequestFromParts(http.MethodGet, "https://example.com/index.html", testHeaderMap, nil, []byte("body")),
+			enc: []byte{
+				// Framing indicator
+				byte(knownLengthRequestFrame),
+				// Request Control Data
+				3, 'G', 'E', 'T',
+				5, 'h', 't', 't', 'p', 's',
+				11, 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm',
+				11, '/', 'i', 'n', 'd', 'e', 'x', '.', 'h', 't', 'm', 'l',
+				// Known-Length Field Section (Headers)
+				15,
+				10, 't', 'e', 's', 't', 'h', 'e', 'a', 'd', 'e', 'r',
+				3, 'f', 'o', 'o',
+				// Known-Length Content
+				4, 'b', 'o', 'd', 'y',
+				// Known-Length Field Section (Trailers)
+				0, // empty list of fields
+				// Padding
+				// empty
+			},
+		},
+		{
+			request: createFullRequestFromParts(http.MethodGet, "https://example.com/index.html", testHeaderMap, testTrailerMap, []byte("body")),
+			enc: []byte{
+				// Framing indicator
+				byte(knownLengthRequestFrame),
+				// Request Control Data
+				3, 'G', 'E', 'T',
+				5, 'h', 't', 't', 'p', 's',
+				11, 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm',
+				11, '/', 'i', 'n', 'd', 'e', 'x', '.', 'h', 't', 'm', 'l',
+				// Known-Length Field Section (Headers)
+				15,
+				10, 't', 'e', 's', 't', 'h', 'e', 'a', 'd', 'e', 'r',
+				3, 'f', 'o', 'o',
+				// Known-Length Content
+				4, 'b', 'o', 'd', 'y',
+				// Known-Length Field Section (Trailers)
+				16,
+				11, 't', 'e', 's', 't', 't', 'r', 'a', 'i', 'l', 'e', 'r',
+				3, 'b', 'a', 'r',
+				// Padding
+				// empty
+			},
+		},
+	}
+
+	for _, test := range tests {
+		actualRequest, err := UnmarshalBinaryRequest(test.enc)
+
+		if test.expectedError == nil {
+			expectedBinaryRequest := BinaryRequest(*test.request)
+			expectedBytes, err := expectedBinaryRequest.Marshal()
+			require.Nil(t, err, "Expected request marshalling failed")
+
+			actualBinaryRequest := BinaryRequest(*actualRequest)
+			actualBytes, err := actualBinaryRequest.Marshal()
+			require.Nil(t, err, "Actual request marshalling failed")
+
+			require.Equal(t, expectedBytes, actualBytes, "Encoded request mismatch")
+		} else {
+			require.Equal(t, test.expectedError, err, "Expected error mismatch")
+		}
+	}
+}
+
 func createResponseFromParts(statusCode int, headers map[string]string, trailers map[string]string, content []byte) *http.Response {
 	resp := &http.Response{
 		Body:       ioutil.NopCloser(bytes.NewBuffer(content)),


### PR DESCRIPTION
### Summary

This PR introduces the support of indeterminate-length requests as per [Section 3.2](https://www.rfc-editor.org/rfc/rfc9292#section-3.2) of [RFC-9292](https://www.rfc-editor.org/rfc/rfc9292).

### Changes

- `readZeroDelimitedSlice` function reads bytes until `0` terminator is met, returning bytes without this terminator. This function is used for handling indeterminate-length slices as per RFC.
- `readSlice` function, based on `frameIndicator`, calls `readVarintSlice` function for known-length requests/responses or `readZeroDelimitedSlice` function for indeterminate-length requests/responses.
- `readContent` function, in similar way, handles known-length content as well as indeterminate-length content. For indeterminate-length content there is additional function `readContentChunks` that handles content chunks as per RFC.
- Tests for `UnmarshalBinaryRequest` function was added covering both known-length and indeterminate-length requests, as well as verifying some error-producing cases. For simplicity, unmarshalled request marshals back to bytes and compares with bytes from expected response.
- Fixed crash when request contains trailing headers. `Trailer` field in `http.Request` is equal to `nil` by default, so initialization of this field was added when there are trailing headers in request.